### PR TITLE
feat: 회원가입, 로그인 구현 및 security filter 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,56 +1,60 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.5'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.5'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.sparta'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
+    // JWT
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-	// QueryDSL 적용을 위한 의존성 (SpringBoot3.0 부터는 jakarta 사용)
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	// QueryDSL APT 의존성 (annotation processing을 위한 의존성)
-	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
-	// Jakarta API 의존성
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // QueryDSL 적용을 위한 의존성 (SpringBoot3.0 부터는 jakarta 사용)
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    // QueryDSL APT 의존성 (annotation processing을 위한 의존성)
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    // Jakarta API 의존성
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-	// progreSQL
-	runtimeOnly 'org.postgresql:postgresql'
+    // progreSQL
+    runtimeOnly 'org.postgresql:postgresql'
 
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
-	compileOnly 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
 
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/sparta/deliveryminiproject/DeliveryMiniProjectApplication.java
+++ b/src/main/java/com/sparta/deliveryminiproject/DeliveryMiniProjectApplication.java
@@ -2,12 +2,13 @@ package com.sparta.deliveryminiproject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
 @SpringBootApplication
 public class DeliveryMiniProjectApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DeliveryMiniProjectApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(DeliveryMiniProjectApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/controller/UserController.java
@@ -1,0 +1,53 @@
+package com.sparta.deliveryminiproject.domain.user.controller;
+
+import com.sparta.deliveryminiproject.domain.user.dto.SigninRequestDto;
+import com.sparta.deliveryminiproject.domain.user.dto.SignupRequestDto;
+import com.sparta.deliveryminiproject.domain.user.entity.UserRoleEnum;
+import com.sparta.deliveryminiproject.domain.user.service.UserService;
+import com.sparta.deliveryminiproject.global.exception.ApiException;
+import com.sparta.deliveryminiproject.global.security.UserDetailsImpl;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ResponseBody
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+  private AuthenticationManager authenticationManager;
+  private final UserService userService;
+
+  @PostMapping("/signup")
+  public void signup(SignupRequestDto requestDto) {
+    userService.signup(requestDto);
+  }
+
+  @GetMapping("/info")
+  public void users(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    System.out.println(
+        "current signed user & role : " + userDetails.getUsername() + userDetails.getAuthorities());
+  }
+
+  @ExceptionHandler({IllegalArgumentException.class})
+  public ResponseEntity<ApiException> handleException(IllegalArgumentException ex) {
+    ApiException restApiException = new ApiException(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    return new ResponseEntity<>(
+        restApiException,
+        HttpStatus.BAD_REQUEST
+    );
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/dto/SigninRequestDto.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/dto/SigninRequestDto.java
@@ -1,0 +1,13 @@
+package com.sparta.deliveryminiproject.domain.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SigninRequestDto {
+
+  private String username;
+  private String password;
+
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/dto/SignupRequestDto.java
@@ -1,0 +1,12 @@
+package com.sparta.deliveryminiproject.domain.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupRequestDto {
+
+  private String username;
+  private String password;
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/entity/User.java
@@ -1,0 +1,42 @@
+package com.sparta.deliveryminiproject.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "p_user")
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String username;
+
+  @Column(nullable = false)
+  private String password;
+
+  @Column(nullable = false)
+  @Enumerated(value = EnumType.STRING)
+  private UserRoleEnum role;
+
+  public User(String username, String password, UserRoleEnum role) {
+    this.username = username;
+    this.password = password;
+    this.role = role;
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/entity/UserRoleEnum.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/entity/UserRoleEnum.java
@@ -1,0 +1,26 @@
+package com.sparta.deliveryminiproject.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public enum UserRoleEnum {
+  CUSTOMER(Authority.CUSTOMER),
+  OWNER(Authority.OWNER),
+  MANAGER(Authority.MANAGER),
+  MASTER(Authority.MASTER);
+
+  private final String authority;
+
+  UserRoleEnum(String authority) {
+    this.authority = authority;
+  }
+
+  public static class Authority {
+
+    public static final String CUSTOMER = "ROLE_CUSTOMER";
+    public static final String OWNER = "ROLE_OWNER";
+    public static final String MANAGER = "ROLE_MANAGER";
+    public static final String MASTER = "ROLE_MASTER";
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.deliveryminiproject.domain.user.repository;
+
+import com.sparta.deliveryminiproject.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/service/UserService.java
@@ -1,0 +1,37 @@
+package com.sparta.deliveryminiproject.domain.user.service;
+
+import com.sparta.deliveryminiproject.domain.user.dto.SigninRequestDto;
+import com.sparta.deliveryminiproject.domain.user.dto.SignupRequestDto;
+import com.sparta.deliveryminiproject.domain.user.entity.User;
+import com.sparta.deliveryminiproject.domain.user.entity.UserRoleEnum;
+import com.sparta.deliveryminiproject.domain.user.repository.UserRepository;
+import com.sparta.deliveryminiproject.global.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
+
+  public void signup(SignupRequestDto requestDto) {
+
+    String username = requestDto.getUsername();
+    String password = passwordEncoder.encode(requestDto.getPassword());
+
+    Optional<User> checkUsername = userRepository.findByUsername(username);
+    if (checkUsername.isPresent()) {
+      throw new IllegalArgumentException("Duplicate username found");
+    }
+
+    // TODO: 권한
+    User user = new User(username, password, UserRoleEnum.MANAGER);
+    userRepository.save(user);
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/config/SecurityConfig.java
@@ -1,0 +1,77 @@
+package com.sparta.deliveryminiproject.global.config;
+
+import com.sparta.deliveryminiproject.global.security.JwtAuthenticationFilter;
+import com.sparta.deliveryminiproject.global.security.JwtAuthorizationFilter;
+import com.sparta.deliveryminiproject.global.jwt.JwtUtil;
+import com.sparta.deliveryminiproject.global.security.UserDetailsServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final JwtUtil jwtUtil;
+  private final UserDetailsServiceImpl userDetailsService;
+  private final AuthenticationConfiguration authenticationConfiguration;
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+      throws Exception {
+    return configuration.getAuthenticationManager();
+  }
+
+  @Bean
+  public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+    filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+    return filter;
+  }
+
+  @Bean
+  public JwtAuthorizationFilter jwtAuthorizationFilter() {
+    return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf((csrf) -> csrf.disable());
+
+    http
+        .formLogin((formLogin) -> formLogin.disable());
+
+    http
+        .httpBasic((httpBasic) -> httpBasic.disable());
+
+    http.authorizeHttpRequests((authorizeHttpRequests) ->
+        authorizeHttpRequests
+            .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
+            .permitAll()
+            .requestMatchers("/api/users/signin").permitAll()
+            .requestMatchers("/api/users/signup").permitAll()
+            .anyRequest().authenticated()
+    );
+
+    http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+    http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/global/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/jwt/JwtUtil.java
@@ -1,0 +1,116 @@
+package com.sparta.deliveryminiproject.global.jwt;
+
+import com.sparta.deliveryminiproject.domain.user.entity.UserRoleEnum;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JwtUtil {
+
+  public static final String AUTHORIZATION_HEADER = "Authorization";
+  public static final String AUTHORIZATION_KEY = "auth";
+  public static final String BEARER_PREFIX = "Bearer ";
+  private final long TOKEN_TIME = 24 * 60 * 60 * 1000L; // 24 hours
+
+  @Value("${jwt.secret.key}")
+  private String secretKey;
+  private Key key;
+  private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+  @PostConstruct
+  public void init() {
+    byte[] bytes = Base64.getDecoder().decode(secretKey);
+    key = Keys.hmacShaKeyFor(bytes);
+  }
+
+  public String createToken(String username, UserRoleEnum role) {
+    Date date = new Date();
+
+    return BEARER_PREFIX +
+        Jwts.builder()
+            .setSubject(username)
+            .claim(AUTHORIZATION_KEY, role)
+            .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+            .setIssuedAt(date)
+            .signWith(key, signatureAlgorithm)
+            .compact();
+  }
+
+  public void addJwtToCookie(String token, HttpServletResponse res) {
+    try {
+      token = URLEncoder.encode(token, "utf-8")
+          .replaceAll("\\+", "%20");
+
+      Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token);
+      cookie.setPath("/");
+
+      res.addCookie(cookie);
+    } catch (UnsupportedEncodingException e) {
+      System.out.println(e.getMessage());
+    }
+  }
+
+  public String substringToken(String tokenValue) {
+    if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+      return tokenValue.substring(7);
+    }
+    throw new NullPointerException("Not Found Token");
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+      return true;
+    } catch (SecurityException | MalformedJwtException | SignatureException e) {
+      System.out.println("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+    } catch (ExpiredJwtException e) {
+      System.out.println("Expired JWT token, 만료된 JWT token 입니다.");
+    } catch (UnsupportedJwtException e) {
+      System.out.println("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+    } catch (IllegalArgumentException e) {
+      System.out.println("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+    }
+    return false;
+  }
+
+  public Claims getUserInfoFromToken(String token) {
+    return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+  }
+
+  public String getTokenFromRequest(HttpServletRequest req) {
+    Cookie[] cookies = req.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (cookie.getName().equals(AUTHORIZATION_HEADER)) {
+          try {
+            return URLDecoder.decode(cookie.getValue(), "UTF-8");
+          } catch (UnsupportedEncodingException e) {
+            return null;
+          }
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.sparta.deliveryminiproject.global.security;
+
+import com.sparta.deliveryminiproject.domain.user.entity.UserRoleEnum;
+import com.sparta.deliveryminiproject.global.jwt.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+  private final JwtUtil jwtUtil;
+
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest request,
+      HttpServletResponse response) throws AuthenticationException {
+
+    String username = obtainUsername(request);
+    String password = obtainPassword(request);
+
+    return getAuthenticationManager().authenticate(
+        new UsernamePasswordAuthenticationToken(
+            username,
+            password,
+            null
+        )
+    );
+  }
+
+  @Override
+  protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+      FilterChain chain, Authentication authResult) throws IOException, ServletException {
+    String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
+    UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+
+    String token = jwtUtil.createToken(username, role);
+    jwtUtil.addJwtToCookie(token, response);
+  }
+
+  @Override
+  protected void unsuccessfulAuthentication(HttpServletRequest request,
+      HttpServletResponse response, AuthenticationException failed)
+      throws IOException, ServletException {
+    response.setStatus(401);
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/global/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/security/JwtAuthorizationFilter.java
@@ -1,0 +1,65 @@
+package com.sparta.deliveryminiproject.global.security;
+
+import com.sparta.deliveryminiproject.global.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+  private final JwtUtil jwtUtil;
+  private final UserDetailsServiceImpl userDetailsService;
+
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String tokenValue = jwtUtil.getTokenFromRequest(req);
+
+    if (StringUtils.hasText(tokenValue)) {
+      tokenValue = jwtUtil.substringToken(tokenValue);
+
+      if (!jwtUtil.validateToken(tokenValue)) {
+        return;
+      }
+
+      Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
+
+      try {
+        setAuthentication(info.getSubject());
+      } catch (Exception e) {
+        System.out.println(e.getMessage());
+        return;
+      }
+    }
+
+    filterChain.doFilter(req, res);
+  }
+
+  public void setAuthentication(String username) {
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+    Authentication authentication = createAuthentication(username);
+    context.setAuthentication(authentication);
+
+    SecurityContextHolder.setContext(context);
+  }
+
+  private Authentication createAuthentication(String username) {
+    UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+    return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/security/UserDetailsImpl.java
@@ -1,0 +1,44 @@
+package com.sparta.deliveryminiproject.global.security;
+
+import com.sparta.deliveryminiproject.domain.user.entity.User;
+import com.sparta.deliveryminiproject.domain.user.entity.UserRoleEnum;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+  private final User user;
+
+  public UserDetailsImpl(User user) {
+    this.user = user;
+  }
+
+  @Override
+  public String getPassword() {
+    return user.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return user.getUsername();
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    UserRoleEnum role = user.getRole();
+    String authority = role.getAuthority();
+
+    SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+    Collection<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(simpleGrantedAuthority);
+
+    return authorities;
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/security/UserDetailsServiceImpl.java
@@ -1,0 +1,24 @@
+package com.sparta.deliveryminiproject.global.security;
+
+import com.sparta.deliveryminiproject.domain.user.entity.User;
+import com.sparta.deliveryminiproject.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    User user = userRepository.findByUsername(username)
+        .orElseThrow(() -> new UsernameNotFoundException("Not Found User"));
+
+    return new UserDetailsImpl(user);
+  }
+}


### PR DESCRIPTION
### 구현 사항

- 회원 가입 구현
- 로그인 구현 ("/login" URL을 호출해주세요!)
- Spring Security 인증 인가 필터 구현
- JWT 관련 유틸 클래스 구현 
- SecurityConfig 구현

### 논의 사항

- response도 error handler처럼 공통화 시킬 수 있더라구요! 해당 부분에 대한 논의가 필요합니다!
  - 재현님이 만들어주신 ApiResponse 사용하기
- 현재 "api/users/signin"에 대한 로그인 처리가 되지 않고 있습니다. (formLogin이 disable라서, default로 "/login"이 잡히고 있어요!)
  - 해당 내용은 튜터님께 여쭤보고 수정하는게 좋을 것 같습니다!
- 권한을 언제? 어떻게? 입력 받을건지? 에 대한 사양이 필요합니다! (기획서엔,, 없는 듯 하여,, 논의가 필요해요!)
  - 초기 회원가입 시엔 "CUSTOMER" 이후 요청에 대한 API 제공!

그밖에 문의사항 있으시면 코멘트부탁드립니다! (--)(__)