### PR TITLE
feat: 카테고리 초기 엔티티 및 기능 구현

### DIFF
--- a/src/main/java/com/sparta/deliveryminiproject/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/category/controller/CategoryController.java
@@ -1,0 +1,53 @@
+package com.sparta.deliveryminiproject.domain.category.controller;
+
+
+import com.sparta.deliveryminiproject.domain.category.dto.CategoryRequestDto;
+import com.sparta.deliveryminiproject.domain.category.dto.CategoryResponseDto;
+import com.sparta.deliveryminiproject.domain.category.service.CategoryService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/categorys")
+public class CategoryController {
+
+  private final CategoryService categoryService;
+
+  public CategoryController(CategoryService categoryService) {
+    this.categoryService = categoryService;
+  }
+
+  // 카테고리 등록
+  @PostMapping("")
+  public void createCategory(@Valid CategoryRequestDto requestDto) {
+    categoryService.createCategory(requestDto);
+  }
+
+  // 카테고리 수정
+  @PutMapping("/{id}")
+  public void updateCategory(@PathVariable UUID id, @Valid CategoryRequestDto requestDto) {
+    categoryService.updateCategory(id, requestDto);
+  }
+
+  // 카테고리 키워드 검색
+  @GetMapping("")
+  public List<CategoryResponseDto> getCategoryByKeyword(
+      @RequestParam(required = false) String searchQuery) {
+    return categoryService.getCategoryByKeyword(searchQuery);
+  }
+
+  // 카테고리 삭제
+  @DeleteMapping("/{id}")
+  public void deleteCategory(@PathVariable UUID id) {
+    categoryService.deleteCategory(id);
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/category/dto/CategoryRequestDto.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/category/dto/CategoryRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.deliveryminiproject.domain.category.dto;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class CategoryRequestDto {
+
+  // 한/영 + 글자수 제한 정규표현식
+  @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣]{1,10}$", message = "1 ~ 10자 사이의 한글과 영대소문자만 입력 가능합니다.")
+  private String categoryName;
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/category/dto/CategoryResponseDto.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/category/dto/CategoryResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.deliveryminiproject.domain.category.dto;
+
+import com.sparta.deliveryminiproject.domain.category.entity.Category;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class CategoryResponseDto {
+
+  private UUID id;
+  private String categoryName;
+
+  public CategoryResponseDto(Category category) {
+    this.id = category.getId();
+    this.categoryName = category.getCategoryName();
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/category/entity/Category.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/category/entity/Category.java
@@ -1,0 +1,31 @@
+package com.sparta.deliveryminiproject.domain.category.entity;
+
+import com.sparta.deliveryminiproject.domain.category.dto.CategoryRequestDto;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Entity(name = "p_category")
+@NoArgsConstructor
+public class Category {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "category_id", unique = true, nullable = false)
+  private UUID id;
+
+  @Setter
+  @Column(nullable = false)
+  private String categoryName;
+
+  public Category(CategoryRequestDto dto) {
+    this.categoryName = dto.getCategoryName();
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,14 @@
+package com.sparta.deliveryminiproject.domain.category.repository;
+
+import com.sparta.deliveryminiproject.domain.category.entity.Category;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+
+  Optional<Category> findByCategoryName(String categoryName);
+
+  List<Category> findAllByCategoryNameContaining(String searchQuery);
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/category/service/CategoryService.java
@@ -1,0 +1,69 @@
+package com.sparta.deliveryminiproject.domain.category.service;
+
+import com.sparta.deliveryminiproject.domain.category.dto.CategoryRequestDto;
+import com.sparta.deliveryminiproject.domain.category.dto.CategoryResponseDto;
+import com.sparta.deliveryminiproject.domain.category.entity.Category;
+import com.sparta.deliveryminiproject.domain.category.repository.CategoryRepository;
+import com.sparta.deliveryminiproject.global.exception.ApiException;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CategoryService {
+
+  private final CategoryRepository categoryRepository;
+
+  public CategoryService(CategoryRepository categoryRepository) {
+    this.categoryRepository = categoryRepository;
+  }
+
+  public void createCategory(CategoryRequestDto requestDto) {
+    checkCategoryExist(requestDto.getCategoryName());
+
+    // 카테고리 생성
+    categoryRepository.save(new Category(requestDto));
+  }
+
+  // DirtyCheck
+  @Transactional
+  public void updateCategory(UUID id, @Valid CategoryRequestDto requestDto) {
+    checkCategoryExist(requestDto.getCategoryName());
+
+    Category category = checkCategoryExist(id);
+
+    // 카테고리명 수정
+    category.setCategoryName(requestDto.getCategoryName());
+  }
+
+  public List<CategoryResponseDto> getCategoryByKeyword(String searchQuery) {
+    if (searchQuery != null && !searchQuery.isEmpty()) {
+      return categoryRepository.findAllByCategoryNameContaining(searchQuery)
+          .stream().map(CategoryResponseDto::new).toList();
+    } else {
+      return categoryRepository.findAll()
+          .stream().map(CategoryResponseDto::new).toList();
+    }
+  }
+
+  public void deleteCategory(UUID id) {
+    checkCategoryExist(id);
+    categoryRepository.deleteById(id);
+  }
+
+  // DB내 카테고리 이름 중복 체크 - 오버라이딩
+  private void checkCategoryExist(String categoryName) {
+    if (categoryRepository.findByCategoryName(categoryName).isPresent()) {
+      throw new ApiException("이미 존재하는 카테고리명 입니다.", HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  // DB내 카테고리 Id 체크 - 오버라이딩
+  private Category checkCategoryExist(UUID id) {
+    return categoryRepository.findById(id).orElseThrow(() ->
+        new ApiException("해당하는 카테고리가 존재하지 않습니다.", HttpStatus.BAD_REQUEST));
+  }
+}


### PR DESCRIPTION
### 구현 내용
- 카테고리 생성 
  - 파라미터 String -> RequestDto로 변경
  - 1 ~ 10자 사이의 한글과 영대소문자만 입력 제한하게 Vaildate
- 카테고리 수정
  - 생성과 동일하게 Vaildate
- 카테고리 키워드 검색
  - 키워드 null 검색 가능(별도 Validate 없음)
- 카테고리 삭제

### 해결해야할 내용
AuditingEntity 적용 후 BaseEntity 상속 적용
API Response - Success 부분에 대하여 논의 필요