### PR TITLE
Fix: BaseEntity 및 공통 응답/예외 처리 수정

### DIFF
--- a/src/main/java/com/sparta/deliveryminiproject/global/entity/BaseEntity.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/entity/BaseEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -37,6 +38,7 @@ public abstract class BaseEntity {
   private String updatedBy;
 
   @Column(nullable = false)
+  @Setter
   private Boolean isDeleted = false;
 
 }

--- a/src/main/java/com/sparta/deliveryminiproject/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/exception/GlobalExceptionHandler.java
@@ -17,8 +17,9 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(ApiException.class)
-  public ResponseEntity<ApiResponse> apiExceptionHandler(ApiException ex) {
-    return ResponseEntity.status(ex.getStatus()).body(ApiResponse.error(ex.getMsg()));
+  public ResponseEntity apiExceptionHandler(ApiException ex) {
+    return ResponseEntity.status(ex.getStatus())
+        .body(ApiResponse.error(ex.getStatus().value(), ex.getMsg()));
   }
 
 }

--- a/src/main/java/com/sparta/deliveryminiproject/global/response/ApiResponse.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/response/ApiResponse.java
@@ -1,56 +1,30 @@
 package com.sparta.deliveryminiproject.global.response;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ApiResponse<T> {
 
-  private static final String SUCCESS_STATUS = "success";
-  private static final String FAIL_STATUS = "fail";
-  private static final String ERROR_STATUS = "error";
-
-  private String status;
-  private T data;
+  private int statusCode;
   private String message;
 
-  public static <T> ApiResponse<T> success(T data) {
-    return new ApiResponse<>(SUCCESS_STATUS, data, null);
-  }
-
-  public static ApiResponse<?> success() {
-    return new ApiResponse<>(SUCCESS_STATUS, null, null);
-  }
-
   public static ApiResponse<?> fail(BindingResult bindingResult) {
-    Map<Object, Object> errors = new HashMap<>();
-
     List<ObjectError> allErrors = bindingResult.getAllErrors();
-    for (ObjectError error : allErrors) {
-      if (error instanceof FieldError) {
-        errors.put(((FieldError) error).getField(), error.getDefaultMessage());
-      } else {
-        errors.put(error.getObjectName(), error.getDefaultMessage());
-      }
-    }
-    return new ApiResponse<>(FAIL_STATUS, errors, null);
+    return new ApiResponse<>(400, allErrors.get(0).getDefaultMessage());
   }
 
-  public static ApiResponse<?> error(String message) {
-    return new ApiResponse<>(ERROR_STATUS, null, message);
+  public static ApiResponse<?> error(int statusCode, String message) {
+    return new ApiResponse<>(statusCode, message);
   }
 
-  private ApiResponse(String status, T data, String message) {
-    this.status = status;
-    this.data = data;
+  private ApiResponse(int statusCode, String message) {
+    this.statusCode = statusCode;
     this.message = message;
   }
 }


### PR DESCRIPTION
### 수정 내용
- `BaseEntity`의 `isDeleted` 필드에 `@Setter` 애노테이션 추가
- 공통 응답 및 에러 처리 수정
  - 성공시 응답값은 제외
  - 실패시 `statusCode`, `message`를 포함하여 반환
  - Validation 검증 실패시 에러 처리 로직 변경