### PR TITLE
feat: 주문 생성 기능 구현

### DIFF
--- a/src/main/java/com/sparta/deliveryminiproject/domain/cart/entity/Cart.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/cart/entity/Cart.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "p_cart")
@@ -46,6 +47,7 @@ public class Cart extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "order_id")
+  @Setter
   private Order order;
 
   @Builder

--- a/src/main/java/com/sparta/deliveryminiproject/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/order/controller/OrderController.java
@@ -1,13 +1,32 @@
 package com.sparta.deliveryminiproject.domain.order.controller;
 
+import com.sparta.deliveryminiproject.domain.order.dto.OrderRequestDto;
+import com.sparta.deliveryminiproject.domain.order.entity.Order;
 import com.sparta.deliveryminiproject.domain.order.service.OrderService;
+import com.sparta.deliveryminiproject.domain.payment.service.PaymentService;
+import com.sparta.deliveryminiproject.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/orders")
 public class OrderController {
 
   private final OrderService orderService;
+  private final PaymentService paymentService;
 
+  @PostMapping
+  public ResponseEntity createOrder(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @RequestBody OrderRequestDto orderRequestDto) {
+    Order order = orderService.createOrder(userDetails.getUser(), orderRequestDto);
+    paymentService.payToOrder(order);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/com/sparta/deliveryminiproject/domain/order/dto/OrderRequestDto.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/order/dto/OrderRequestDto.java
@@ -1,0 +1,30 @@
+package com.sparta.deliveryminiproject.domain.order.dto;
+
+import com.sparta.deliveryminiproject.domain.order.entity.Order;
+import com.sparta.deliveryminiproject.domain.order.entity.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OrderRequestDto {
+
+  private String requests;
+  private String address;
+  private String phoneNumber;
+
+  @Builder
+  private OrderRequestDto(String requests, String address, String phoneNumber) {
+    this.requests = requests;
+    this.address = address;
+    this.phoneNumber = phoneNumber;
+  }
+
+  public Order toEntity(OrderRequestDto orderRequestDto) {
+    return Order.builder()
+        .requests(orderRequestDto.getRequests())
+        .address(orderRequestDto.getAddress())
+        .phoneNumber(orderRequestDto.getPhoneNumber())
+        .orderStatus(OrderStatus.PENDING_PAYMENT)
+        .build();
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/order/entity/Order.java
@@ -1,21 +1,30 @@
 package com.sparta.deliveryminiproject.domain.order.entity;
 
+import com.sparta.deliveryminiproject.domain.cart.entity.Cart;
+import com.sparta.deliveryminiproject.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "p_order")
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class Order {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -27,4 +36,40 @@ public class Order {
 
   private String address;
 
+  private String phoneNumber;
+
+  @Setter
+  @Enumerated(value = EnumType.STRING)
+  private OrderType orderType;
+
+  @Setter
+  @Enumerated(value = EnumType.STRING)
+  private OrderStatus orderStatus;
+
+  @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+  private List<Cart> cartList = new ArrayList<>();
+
+  @Builder
+  private Order(UUID id, int totalPrice, String requests, String address, String phoneNumber,
+      OrderType orderType, OrderStatus orderStatus) {
+    this.id = id;
+    this.totalPrice = totalPrice;
+    this.requests = requests;
+    this.address = address;
+    this.phoneNumber = phoneNumber;
+    this.orderType = orderType;
+    this.orderStatus = orderStatus;
+  }
+
+  public void addCartList(Cart cart) {
+    cartList.add(cart);
+    cart.setOrder(this);
+  }
+
+  public void calculateAndSetTotalPrice() {
+    totalPrice = cartList.stream()
+        .map(cart -> cart.getQuantity() * cart.getMenu().getPrice())
+        .mapToInt(Integer::intValue)
+        .sum() + cartList.get(0).getShop().getDeliveryTip();
+  }
 }

--- a/src/main/java/com/sparta/deliveryminiproject/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/order/entity/OrderStatus.java
@@ -1,0 +1,19 @@
+package com.sparta.deliveryminiproject.domain.order.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderStatus {
+  PENDING_PAYMENT("결제 대기"),
+  PAID("결제 완료"),
+  PREPARING("준비 중"),
+  DELIVERED("배달 완료"),
+  CANCELED("주문 취소"),
+  REFUNDED("환불 완료");
+
+  private final String description;
+
+  OrderStatus(String description) {
+    this.description = description;
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/order/entity/OrderType.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/order/entity/OrderType.java
@@ -1,0 +1,15 @@
+package com.sparta.deliveryminiproject.domain.order.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderType {
+  ONLINE("온라인 주문"),
+  STORE("대면 주문");
+
+  private final String description;
+
+  OrderType(String description) {
+    this.description = description;
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/order/service/OrderService.java
@@ -1,13 +1,36 @@
 package com.sparta.deliveryminiproject.domain.order.service;
 
+import com.sparta.deliveryminiproject.domain.cart.repository.CartRepository;
+import com.sparta.deliveryminiproject.domain.order.dto.OrderRequestDto;
+import com.sparta.deliveryminiproject.domain.order.entity.Order;
+import com.sparta.deliveryminiproject.domain.order.entity.OrderType;
 import com.sparta.deliveryminiproject.domain.order.repository.OrderRepository;
+import com.sparta.deliveryminiproject.domain.user.entity.User;
+import com.sparta.deliveryminiproject.domain.user.entity.UserRoleEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderService {
 
   private final OrderRepository orderRepository;
+  private final CartRepository cartRepository;
 
+  @Transactional
+  public Order createOrder(User user, OrderRequestDto orderRequestDto) {
+    Order order = orderRequestDto.toEntity(orderRequestDto);
+
+    cartRepository.findAllByUserAndIsDeletedFalse(user)
+        .forEach(order::addCartList);
+
+    order.setOrderType(
+        user.getRole().equals(UserRoleEnum.OWNER) ? OrderType.STORE : OrderType.ONLINE);
+
+    order.calculateAndSetTotalPrice();
+
+    return orderRepository.save(order);
+  }
 }

--- a/src/main/java/com/sparta/deliveryminiproject/domain/payment/entity/Payment.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/payment/entity/Payment.java
@@ -1,0 +1,44 @@
+package com.sparta.deliveryminiproject.domain.payment.entity;
+
+import com.sparta.deliveryminiproject.domain.order.entity.Order;
+import com.sparta.deliveryminiproject.global.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_payment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  private String paymentMethod;
+
+  private int totalPrice;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "order_id")
+  private Order order;
+
+  @Builder
+  private Payment(UUID id, String paymentMethod, int totalPrice, Order order) {
+    this.id = id;
+    this.paymentMethod = paymentMethod;
+    this.totalPrice = totalPrice;
+    this.order = order;
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.deliveryminiproject.domain.payment.repository;
+
+import com.sparta.deliveryminiproject.domain.payment.entity.Payment;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/payment/service/PaymentService.java
@@ -1,0 +1,30 @@
+package com.sparta.deliveryminiproject.domain.payment.service;
+
+import com.sparta.deliveryminiproject.domain.order.entity.Order;
+import com.sparta.deliveryminiproject.domain.order.entity.OrderStatus;
+import com.sparta.deliveryminiproject.domain.payment.entity.Payment;
+import com.sparta.deliveryminiproject.domain.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentService {
+
+  private final PaymentRepository paymentRepository;
+
+  @Transactional
+  public void payToOrder(Order order) {
+    Payment payment = Payment.builder()
+        .paymentMethod("카드 결제")
+        .totalPrice(order.getTotalPrice())
+        .order(order)
+        .build();
+
+    order.setOrderStatus(OrderStatus.PAID);
+
+    paymentRepository.save(payment);
+  }
+}


### PR DESCRIPTION
### 구현 내용
- 주문 생성 기능 구현
  - 사용자의 권한이 OWNER일 때는 대면 주문, 그 외일 때는 가게 주문으로 처리
  - 주문을 했을 떄, 상태값은 주문의 상태는 "결제 전"이고 PayService에서 결제가 완료될 시에 "결제 완료"상태로 변경