### PR TITLE
feat: Gemini AI API 응답 요청 구현

### DIFF
--- a/src/main/java/com/sparta/deliveryminiproject/domain/gemini/Entity/Gemini.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/gemini/Entity/Gemini.java
@@ -1,0 +1,27 @@
+package com.sparta.deliveryminiproject.domain.gemini.Entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Entity(name = "p_gemini")
+@NoArgsConstructor
+public class Gemini {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "gemini_id")
+  private UUID id;
+
+  @Setter
+  @Column(nullable = false)
+  private String requestKeyword;
+
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/gemini/config/GeminiRestTemplateConfig.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/gemini/config/GeminiRestTemplateConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class GeminiRestTemplateConfig {
 
-  @Bean
+  @Bean(name = "geminiRestTemplate")
   public RestTemplate geminiRestTemplate() {
     return new RestTemplate();
 

--- a/src/main/java/com/sparta/deliveryminiproject/domain/gemini/config/GeminiRestTemplateConfig.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/gemini/config/GeminiRestTemplateConfig.java
@@ -1,0 +1,16 @@
+package com.sparta.deliveryminiproject.domain.gemini.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class GeminiRestTemplateConfig {
+
+  @Bean
+  public RestTemplate geminiRestTemplate() {
+    return new RestTemplate();
+
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/gemini/controller/GeminiController.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/gemini/controller/GeminiController.java
@@ -1,0 +1,24 @@
+package com.sparta.deliveryminiproject.domain.gemini.controller;
+
+import com.sparta.deliveryminiproject.domain.gemini.dto.GeminiRequestDto;
+import com.sparta.deliveryminiproject.domain.gemini.utility.GeminiUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/gemini")
+public class GeminiController {
+
+  private final GeminiUtil geminiUtil;
+
+  public GeminiController(GeminiUtil geminiUtil) {
+    this.geminiUtil = geminiUtil;
+  }
+
+  @PostMapping
+  public ResponseEntity<?> sendGeminiMessage(GeminiRequestDto requestDto) {
+    return geminiUtil.sendGeminiMessage(requestDto);
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/gemini/controller/GeminiController.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/gemini/controller/GeminiController.java
@@ -18,7 +18,7 @@ public class GeminiController {
   }
 
   @PostMapping
-  public ResponseEntity<?> sendGeminiMessage(GeminiRequestDto requestDto) {
-    return geminiUtil.sendGeminiMessage(requestDto);
+  public ResponseEntity<?> requestGeminiResponse(GeminiRequestDto requestDto) {
+    return geminiUtil.requestGeminiResponse(requestDto);
   }
 }

--- a/src/main/java/com/sparta/deliveryminiproject/domain/gemini/dto/GeminiRequestDto.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/gemini/dto/GeminiRequestDto.java
@@ -1,0 +1,40 @@
+package com.sparta.deliveryminiproject.domain.gemini.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class GeminiRequestDto {
+
+  private List<Content> contents;
+
+  @Data
+  public class Content {
+
+    private List<Part> parts;
+
+    public Content(String text) {
+      parts = new ArrayList<>();
+      Part part = new Part(text);
+      parts.add(part);
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public class Part {
+
+      private String text;
+    }
+  }
+
+  public GeminiRequestDto(String menu) {
+    this.contents = new ArrayList<>();
+    Content content = new Content(menu + "에 대한 대해 각각 다른 3가지 설명을 해줘. 설명 별로 간결하게 50자 내외로 작성해줘");
+    contents.add(content);
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/gemini/dto/GeminiResponseDto.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/gemini/dto/GeminiResponseDto.java
@@ -1,0 +1,45 @@
+package com.sparta.deliveryminiproject.domain.gemini.dto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GeminiResponseDto {
+
+  private List<Candidate> candidates;
+
+  @Data
+  public static class Candidate {
+
+    private Content content;
+    private String finishReason;
+  }
+
+  @Data
+  public static class Content {
+
+    private List<Parts> parts;
+    private String role;
+
+  }
+
+  @Getter
+  public static class Parts {
+
+    private String text;
+    private List<String> seperatedText;
+
+    public void setText(String text) {
+      this.text = text;
+      List<String> speratedText = new ArrayList<>(
+          Arrays.stream(text.replace("**", "").split("\\n")).toList());
+      speratedText.removeAll(Arrays.asList("", null));
+      this.seperatedText = speratedText;
+    }
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/gemini/utility/GeminiUtil.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/gemini/utility/GeminiUtil.java
@@ -1,0 +1,38 @@
+package com.sparta.deliveryminiproject.domain.gemini.utility;
+
+
+import com.sparta.deliveryminiproject.domain.gemini.dto.GeminiRequestDto;
+import com.sparta.deliveryminiproject.domain.gemini.dto.GeminiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class GeminiUtil {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${gemini.api.url}")
+  private String apiUrl;
+
+  @Value("${gemini.api.key}")
+  private String apiKey;
+
+  public ResponseEntity sendGeminiMessage(GeminiRequestDto requestDto) {
+    try {
+      String requestUrl = apiUrl + "?key=" + apiKey;
+      GeminiResponseDto responseDto = restTemplate.postForObject(
+          requestUrl,
+          requestDto,
+          GeminiResponseDto.class);
+
+      return ResponseEntity.ok().body(responseDto);
+    } catch (HttpClientErrorException e) {
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/gemini/utility/GeminiUtil.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/gemini/utility/GeminiUtil.java
@@ -3,7 +3,7 @@ package com.sparta.deliveryminiproject.domain.gemini.utility;
 
 import com.sparta.deliveryminiproject.domain.gemini.dto.GeminiRequestDto;
 import com.sparta.deliveryminiproject.domain.gemini.dto.GeminiResponseDto;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -11,10 +11,13 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @Component
-@RequiredArgsConstructor
 public class GeminiUtil {
 
   private final RestTemplate restTemplate;
+
+  public GeminiUtil(@Qualifier("geminiRestTemplate") RestTemplate restTemplate) {
+    this.restTemplate = restTemplate;
+  }
 
   @Value("${gemini.api.url}")
   private String apiUrl;
@@ -22,7 +25,7 @@ public class GeminiUtil {
   @Value("${gemini.api.key}")
   private String apiKey;
 
-  public ResponseEntity sendGeminiMessage(GeminiRequestDto requestDto) {
+  public ResponseEntity requestGeminiResponse(GeminiRequestDto requestDto) {
     try {
       String requestUrl = apiUrl + "?key=" + apiKey;
       GeminiResponseDto responseDto = restTemplate.postForObject(

--- a/src/main/java/com/sparta/deliveryminiproject/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/exception/GlobalExceptionHandler.java
@@ -2,14 +2,27 @@ package com.sparta.deliveryminiproject.global.exception;
 
 import com.sparta.deliveryminiproject.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpServerErrorException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  @ExceptionHandler(HttpServerErrorException.class)
+  public ResponseEntity<ApiResponse> serverErrorHandler(HttpServerErrorException ex) {
+    HttpStatusCode statusCode = ex.getStatusCode();
+    String errorMessage = ex.getMessage();
+    if (errorMessage.contains("he model is overloaded")) {
+      errorMessage = "모델이 과부하되었습니다. 나중에 다시 시도해 주세요.";
+    }
+    return ResponseEntity.status(statusCode)
+        .body(ApiResponse.error(statusCode.value(), errorMessage));
+  }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ApiResponse> handleValidationException(BindingResult bindingResult) {


### PR DESCRIPTION
### 작업 내역
- Google Gemini AI API 연동

### sendGeminiMessage
- application.properties에 추가 설정이 필요합니다.
- "menu" ex)짬뽕, 매개변수만 입력하면 50자 내외 3가지 설명 응답하도록 하드코딩 하였습니다.
이후 가짓수, 글자수 리팩토링 진행하겠습니다.
```
gemini.api.url=https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent
gemini.api.key={your.api.key}
```
- 2번 이상 요청시 높은 확률로 503 error가 발생합니다.
![image](https://github.com/user-attachments/assets/891d2f69-acc2-4699-adeb-55fb56507b3c)
    - 무료 API의 한계인듯 합니다. 잠시 기다렸다 재시도하면 작동합니다. 사용량 확인해 보았으나 많지않았고 API 서버의 문제일 가능성이 큰 듯 합니다.
    - 에러가 자주 발생할듯하여서 전역 예외처리 추가하였습니다.
    - 응답이 상당히 느린 문제도 있습니다. 개선 방안 있을지 리팩토링 해보겠습니다.

### 논의사항
![image](https://github.com/user-attachments/assets/147f09ad-3d95-4dd3-844f-82d1c2e0cd27)
- 우선 구현한 내용으로 Response 에 위와 같이 text, sepertatedText로 이분되도록 생성자 설정하였습니다.
상품 설명 생성시에 변경해야할 내용 있으시면 피드백 부탁드려요~!