### PR TITLE
feat: User 관련 Response 수정 및 필터, 토큰 로직 수정

### DIFF
--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/controller/UserController.java
@@ -1,17 +1,18 @@
 package com.sparta.deliveryminiproject.domain.user.controller;
 
+import com.sparta.deliveryminiproject.domain.user.dto.RoleResponseDto;
 import com.sparta.deliveryminiproject.domain.user.dto.SigninRequestDto;
+import com.sparta.deliveryminiproject.domain.user.dto.SigninResponseDto;
 import com.sparta.deliveryminiproject.domain.user.dto.SignupRequestDto;
 import com.sparta.deliveryminiproject.domain.user.service.UserService;
-import com.sparta.deliveryminiproject.global.jwt.JwtUtil;
 import com.sparta.deliveryminiproject.global.security.UserDetailsImpl;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,7 +25,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 public class UserController {
 
   private final UserService userService;
-  private final JwtUtil jwtUtil;
 
   @PostMapping("/signup")
   public void signup(@Valid SignupRequestDto requestDto) {
@@ -32,8 +32,9 @@ public class UserController {
   }
 
   @PostMapping("/signin")
-  public void signin(SigninRequestDto requestDto, HttpServletResponse response) {
-    userService.signin(requestDto, response);
+  public ResponseEntity signin(SigninRequestDto requestDto, HttpServletResponse response) {
+    SigninResponseDto responseDto = userService.signin(requestDto, response);
+    return ResponseEntity.ok(responseDto);
   }
 
   @PostMapping("/signout")
@@ -43,14 +44,9 @@ public class UserController {
   }
 
   @PostMapping("/role/{role}")
-  public void updateRole(@PathVariable String role,
+  public ResponseEntity updateRole(@PathVariable String role,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
-    userService.updateRole(userDetails.getUser(), role);
-  }
-
-  @GetMapping("/info")
-  public void users(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-    System.out.println(
-        "current signed user & role : " + userDetails.getUsername() + userDetails.getAuthorities());
+    RoleResponseDto responseDto = userService.updateRole(userDetails.getUser(), role);
+    return ResponseEntity.ok(responseDto);
   }
 }

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/dto/RoleResponseDto.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/dto/RoleResponseDto.java
@@ -1,0 +1,21 @@
+package com.sparta.deliveryminiproject.domain.user.dto;
+
+import com.sparta.deliveryminiproject.domain.user.entity.UserRoleEnum;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RoleResponseDto {
+
+  private Long id;
+  UserRoleEnum role;
+
+  public RoleResponseDto(Long id, UserRoleEnum role) {
+    this.id = id;
+    this.role = role;
+  }
+
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/dto/SigninResponseDto.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/dto/SigninResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.deliveryminiproject.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SigninResponseDto {
+
+  private Long id;
+
+  public SigninResponseDto(Long id) {
+    this.id = id;
+  }
+}

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/entity/UserRoleEnum.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/entity/UserRoleEnum.java
@@ -17,7 +17,8 @@ public enum UserRoleEnum {
 
   public static UserRoleEnum contains(String role) {
     for (UserRoleEnum userRole : UserRoleEnum.values()) {
-      if (userRole.getAuthority().equals(role)) {
+      String roleValue = "ROLE_" + role.toUpperCase();
+      if (userRole.getAuthority().equals(roleValue)) {
         return userRole;
       }
     }

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.sparta.deliveryminiproject.domain.user.service;
 
+import com.sparta.deliveryminiproject.domain.user.dto.RoleResponseDto;
 import com.sparta.deliveryminiproject.domain.user.dto.SigninRequestDto;
+import com.sparta.deliveryminiproject.domain.user.dto.SigninResponseDto;
 import com.sparta.deliveryminiproject.domain.user.dto.SignupRequestDto;
 import com.sparta.deliveryminiproject.domain.user.entity.User;
 import com.sparta.deliveryminiproject.domain.user.entity.UserRoleEnum;
@@ -42,13 +44,13 @@ public class UserService {
     userRepository.save(user);
   }
 
-  public void signin(SigninRequestDto requestDto, HttpServletResponse response) {
+  public SigninResponseDto signin(SigninRequestDto requestDto, HttpServletResponse response) {
 
     String username = requestDto.getUsername();
     String password = requestDto.getPassword();
 
     User user = userRepository.findByUsername(username).orElseThrow(
-        () -> new IllegalArgumentException("Invalid Username")
+        () -> new ApiException("Invalid Username", HttpStatus.BAD_REQUEST)
     );
 
     if (!passwordEncoder.matches(password, user.getPassword())) {
@@ -57,12 +59,14 @@ public class UserService {
 
     String token = jwtUtil.createToken(username, user.getRole());
     jwtUtil.addJwtToCookie(token, response);
+
+    return new SigninResponseDto(user.getId());
   }
 
   public void signout(User user, HttpServletRequest request, HttpServletResponse response) {
 
     userRepository.findByUsername(user.getUsername())
-        .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        .orElseThrow(() -> new ApiException("User not found", HttpStatus.BAD_REQUEST));
 
     String token = jwtUtil.getTokenFromRequest(request);
     Long expSec = jwtUtil.getUserInfoFromToken(jwtUtil.substringToken(token)).getExpiration()
@@ -74,15 +78,16 @@ public class UserService {
   }
 
   @Transactional
-  public void updateRole(User user, String role) {
+  public RoleResponseDto updateRole(User user, String role) {
     User savedUser = userRepository.findByUsername(user.getUsername())
-        .orElseThrow(() -> new IllegalArgumentException("User not found"));
-    UserRoleEnum roleEnum = UserRoleEnum.contains(role);
+        .orElseThrow(() -> new ApiException("User not found", HttpStatus.BAD_REQUEST));
 
+    UserRoleEnum roleEnum = UserRoleEnum.contains(role);
     if (roleEnum == null) {
       throw new ApiException("Not Valid Role", HttpStatus.BAD_REQUEST);
     }
 
     savedUser.setRole(roleEnum);
+    return new RoleResponseDto(savedUser.getId(), savedUser.getRole());
   }
 }

--- a/src/main/java/com/sparta/deliveryminiproject/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.sparta.deliveryminiproject.global.security.RedisUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.util.Date;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -64,7 +65,11 @@ public class UserService {
         .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
     String token = jwtUtil.getTokenFromRequest(request);
-    redisUtil.addToBlackList(token);
+    Long expSec = jwtUtil.getUserInfoFromToken(jwtUtil.substringToken(token)).getExpiration()
+        .getTime();
+    Long nowSec = new Date().getTime();
+
+    redisUtil.addToBlackList(token, expSec - nowSec);
     jwtUtil.deleteJwtToCookie(request, response);
   }
 

--- a/src/main/java/com/sparta/deliveryminiproject/global/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/security/JwtAuthorizationFilter.java
@@ -1,5 +1,7 @@
 package com.sparta.deliveryminiproject.global.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.deliveryminiproject.global.exception.ApiException;
 import com.sparta.deliveryminiproject.global.jwt.JwtUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -7,6 +9,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -45,6 +48,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         System.out.println(e.getMessage());
         return;
       }
+    } else {
+      res.setStatus(HttpStatus.FORBIDDEN.value());
+      res.setContentType("application/json");
+      res.getWriter().write(new ObjectMapper().writeValueAsString(
+          new ApiException("토큰이 없습니다.", HttpStatus.FORBIDDEN)
+      ));
+      return;
     }
 
     filterChain.doFilter(req, res);

--- a/src/main/java/com/sparta/deliveryminiproject/global/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/security/JwtAuthorizationFilter.java
@@ -31,6 +31,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
   protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
       FilterChain filterChain) throws ServletException, IOException {
 
+    String path = req.getRequestURI();
+    if (path.equals("/api/users/signup") || path.equals("/api/users/signin")) {
+      filterChain.doFilter(req, res);
+      return;
+    }
+
     String tokenValue = jwtUtil.getTokenFromRequest(req);
 
     if (StringUtils.hasText(tokenValue)) {
@@ -52,7 +58,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
       res.setStatus(HttpStatus.FORBIDDEN.value());
       res.setContentType("application/json");
       res.getWriter().write(new ObjectMapper().writeValueAsString(
-          new ApiException("토큰이 없습니다.", HttpStatus.FORBIDDEN)
+          new ApiException("Token Null", HttpStatus.FORBIDDEN)
       ));
       return;
     }

--- a/src/main/java/com/sparta/deliveryminiproject/global/security/RedisUtil.java
+++ b/src/main/java/com/sparta/deliveryminiproject/global/security/RedisUtil.java
@@ -1,5 +1,7 @@
 package com.sparta.deliveryminiproject.global.security;
 
+import com.sparta.deliveryminiproject.global.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -10,8 +12,8 @@ public class RedisUtil {
 
   private final RedisTemplate<String, String> redisTemplate;
 
-  public void addToBlackList(String token) {
-    redisTemplate.opsForValue().set(token, "blacklisted");
+  public void addToBlackList(String token, Long expire) {
+    redisTemplate.opsForValue().set(token, "blacklisted", expire);
   }
 
   public boolean isTokenBlacklisted(String token) {


### PR DESCRIPTION
### 구현 내용
- User Response 추가
  - 회원가입, 로그아웃은 응답줄게 없어서 void 유지했습니다.
  - 로그인, 권한 변경 시 id와 변경된 role을 내려주도록 처리했습니다!
- jwtAuthorizationFilter 내에 url를 통과하는 로직 추가했습니다.
  - securityConfig에서 permitAll() 있음에도 불구하고 필터는 통과하는것으로 확인했습니다.
  - 다른 방법도 있는 듯 합니다! (더 파봐야할거같아서 우선 필터 내에서,, 처리를 했어요,,🥺)
  - https://suhyeon-developer.tistory.com/42
- redis 내 유효시간 설정