### PR TITLE
fix: 주문 최소 금액 예외 처리 적용 및 검색 조건 수정

### DIFF
--- a/src/main/java/com/sparta/deliveryminiproject/domain/order/dto/OrderSearchCondition.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/order/dto/OrderSearchCondition.java
@@ -8,7 +8,6 @@ import lombok.Data;
 @Data
 public class OrderSearchCondition {
 
-  private String category;
   private OrderType orderType;
   private LocalDate startAt;
   private LocalDate endAt;

--- a/src/main/java/com/sparta/deliveryminiproject/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/deliveryminiproject/domain/order/service/OrderService.java
@@ -49,6 +49,11 @@ public class OrderService {
 
     order.calculateAndSetTotalPrice();
 
+    if (order.getOrderType().equals(OrderType.DELIVERY_ORDER)
+        && order.getShop().getMinDeliveryPrice() >= order.getTotalPrice()) {
+      throw new ApiException("총 주문 금액이 최소 주문 금액에 도달하지 않았습니다.", HttpStatus.BAD_REQUEST);
+    }
+
     return orderRepository.save(order);
   }
 


### PR DESCRIPTION
수정 내용
- 장바구니 메뉴의 주문 금액이 가게의 주문 최소 금액 미달일 시에 예외처리
- 검색 조건에서 카테고리 제외